### PR TITLE
Fixed choice of plan in auto mode

### DIFF
--- a/pstate-frequency
+++ b/pstate-frequency
@@ -775,12 +775,12 @@ set_power_plan_automatic()
   log_verbose "Set power plan to: %s" "${set_power_plan_automatic__name}"
   if is_battery_powered; then
     set_power_plan_automatic__config="$(locate_power_plan_config \
-      "${set_power_plan_automatic__ac}")"
-    set_power_plan_automatic__arg="${set_power_plan_automatic__ac}"
-  else
-    set_power_plan_automatic__config="$(locate_power_plan_config \
       "${set_power_plan_automatic__bat}")"
     set_power_plan_automatic__arg="${set_power_plan_automatic__bat}"
+  else
+    set_power_plan_automatic__config="$(locate_power_plan_config \
+      "${set_power_plan_automatic__ac}")"
+    set_power_plan_automatic__arg="${set_power_plan_automatic__ac}"
   fi
 
   # Fail if we don't find a config


### PR DESCRIPTION
The condition (or code ) when choosing which plan to execute was
reversed, so that when on AC power, the battery plan would execute and
vice-versa. This flips it so it works the right way.